### PR TITLE
跑通DML语句和事务操作

### DIFF
--- a/internal/datasource/types.go
+++ b/internal/datasource/types.go
@@ -26,6 +26,7 @@ type Tx interface {
 }
 
 type DataSource interface {
+	TxBeginner
 	Executor
 	Close() error
 }

--- a/internal/protocol/mysql/internal/connection/conn.go
+++ b/internal/protocol/mysql/internal/connection/conn.go
@@ -25,8 +25,9 @@ type Conn struct {
 	Id           uint32
 
 	// onCmd 处理客户端过来的命令
-	onCmd      OnCmd
-	cmdTimeout time.Duration
+	onCmd        OnCmd
+	cmdTimeout   time.Duration
+	InTransition bool
 
 	clientFlags  flags.CapabilityFlags
 	characterSet uint32
@@ -63,9 +64,9 @@ func (mc *Conn) Loop() error {
 		if err1 != nil {
 			return fmt.Errorf("读取客户端请求失败 %w", err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), mc.cmdTimeout)
+		ctx, _ := context.WithTimeout(context.Background(), mc.cmdTimeout)
 		err1 = mc.onCmd(ctx, mc, pkt)
-		cancel()
+		//cancel() // TODO：暂时注释，因为这个会影响事务自动回滚，还不清楚原因
 		if err1 != nil {
 			return err1
 		}

--- a/internal/protocol/mysql/plugin/context/parsed_query.go
+++ b/internal/protocol/mysql/plugin/context/parsed_query.go
@@ -17,6 +17,11 @@ func (q *ParsedQuery) FirstDML() *parser.DmlStatementContext {
 	return dmlStmt.(*parser.DmlStatementContext)
 }
 
+func (q *ParsedQuery) SqlStatement() any {
+	sqlStmt := q.FirstStatement()
+	return sqlStmt.GetChildren()[0]
+}
+
 func (q *ParsedQuery) FirstStatement() *parser.SqlStatementContext {
 	sqlStmts := q.Root.GetChildren()[0]
 	sqlStmt := sqlStmts.GetChildren()[0]

--- a/internal/protocol/mysql/plugin/context/types.go
+++ b/internal/protocol/mysql/plugin/context/types.go
@@ -7,7 +7,8 @@ import (
 type Context struct {
 	context.Context
 	// 这个是解析后的
-	ParsedQuery ParsedQuery
-	Query       string
-	Args        []any
+	ParsedQuery  ParsedQuery
+	Query        string
+	Args         []any
+	InTransition bool
 }

--- a/internal/protocol/mysql/plugin/forward/handler.go
+++ b/internal/protocol/mysql/plugin/forward/handler.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"database/sql"
 	"github.com/meoying/dbproxy/internal/datasource"
 	"github.com/meoying/dbproxy/internal/protocol/mysql/internal/ast/parser"
 	"github.com/meoying/dbproxy/internal/protocol/mysql/plugin"
@@ -11,27 +12,94 @@ import (
 // 一般用于测试环境
 type Handler struct {
 	ds datasource.DataSource
+	tx datasource.Tx
 }
 
 func (f *Handler) Handle(ctx *pcontext.Context) (*plugin.Result, error) {
-	dml := ctx.ParsedQuery.FirstDML()
-	_, ok := dml.GetChildren()[0].(*parser.SelectStatementContext)
-	if ok {
-		rows, err := f.ds.Query(ctx, datasource.Query{
+	var err error
+	result := &plugin.Result{}
+	sqlStmt := ctx.ParsedQuery.SqlStatement()
+	switch sqlStmt.(type) {
+	case *parser.TransactionStatementContext:
+		err = f.handleTransaction(ctx, sqlStmt.(*parser.TransactionStatementContext))
+		result.ChangeTransaction = true
+		return result, err
+	case *parser.DmlStatementContext:
+		return f.handleDml(ctx, sqlStmt.(*parser.DmlStatementContext))
+	}
+	return result, nil
+}
+
+// handleDml 处理DML语句
+func (f *Handler) handleDml(ctx *pcontext.Context, stmt *parser.DmlStatementContext) (*plugin.Result, error) {
+	switch stmt.GetChildren()[0].(type) {
+	case *parser.SimpleSelectContext:
+		return f.handleSelect(ctx)
+	case *parser.InsertStatementContext:
+		return f.handleCUD(ctx)
+	case *parser.UpdateStatementContext:
+		return f.handleCUD(ctx)
+	case *parser.DeleteStatementContext:
+		return f.handleCUD(ctx)
+	}
+	return &plugin.Result{}, nil
+}
+
+// handleSelect 处理Select语句
+func (f *Handler) handleSelect(ctx *pcontext.Context) (*plugin.Result, error) {
+	var rows *sql.Rows
+	var err error
+	if ctx.InTransition {
+		rows, err = f.tx.Query(ctx, datasource.Query{
 			SQL:  ctx.Query,
 			Args: ctx.Args,
 		})
-		return &plugin.Result{
-			Rows: rows,
-		}, err
+	} else {
+		rows, err = f.ds.Query(ctx, datasource.Query{
+			SQL:  ctx.Query,
+			Args: ctx.Args,
+		})
 	}
-	res, err := f.ds.Exec(ctx, datasource.Query{
-		SQL:  ctx.Query,
-		Args: ctx.Args,
-	})
+
+	return &plugin.Result{
+		Rows: rows,
+	}, err
+}
+
+// handleCUD 操作数据
+func (f *Handler) handleCUD(ctx *pcontext.Context) (*plugin.Result, error) {
+	var err error
+	var res sql.Result
+	if ctx.InTransition {
+		res, err = f.tx.Exec(ctx, datasource.Query{
+			SQL:  ctx.Query,
+			Args: ctx.Args,
+		})
+	} else {
+		res, err = f.ds.Exec(ctx, datasource.Query{
+			SQL:  ctx.Query,
+			Args: ctx.Args,
+		})
+	}
+
 	return &plugin.Result{
 		Result: res,
 	}, err
+}
+
+// handleTransaction 处理事务相关语句
+func (f *Handler) handleTransaction(ctx *pcontext.Context, stmt *parser.TransactionStatementContext) error {
+	switch stmt.GetChildren()[0].(type) {
+	case *parser.StartTransactionContext:
+		var err error
+		f.tx, err = f.ds.BeginTx(ctx, nil)
+		return err
+	case *parser.CommitWorkContext:
+		return f.tx.Commit()
+	case *parser.RollbackWorkContext:
+		return f.tx.Rollback()
+	}
+	return nil
 }
 
 func NewHandler(ds datasource.DataSource) *Handler {

--- a/internal/protocol/mysql/plugin/types.go
+++ b/internal/protocol/mysql/plugin/types.go
@@ -38,4 +38,6 @@ type Result struct {
 	Rows sqlx.Rows
 	// Result 的 error 会被传递过去客户端
 	Result sql.Result
+	// ChangeTransaction 是否改变事务的状态
+	ChangeTransaction bool
 }

--- a/internal/protocol/mysql/server_test.go
+++ b/internal/protocol/mysql/server_test.go
@@ -71,6 +71,59 @@ func (s *ServerTestSuite) TestSelect() {
 	}
 }
 
+func (s *ServerTestSuite) TestInsert() {
+	db, err := sql.Open("mysql", "root:root@tcp(localhost:8306)/mysql")
+	require.NoError(s.T(), err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result, err := db.ExecContext(ctx, "insert into users(name) VALUES ('Andy')")
+	require.NoError(s.T(), err)
+	s.T().Log(result)
+}
+
+func (s *ServerTestSuite) TestUpdate() {
+	db, err := sql.Open("mysql", "root:root@tcp(localhost:8306)/mysql")
+	require.NoError(s.T(), err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result, err := db.ExecContext(ctx, "update users set name='Jack' where name = 'Andy'")
+	require.NoError(s.T(), err)
+	s.T().Log(result)
+}
+
+func (s *ServerTestSuite) TestDelete() {
+	db, err := sql.Open("mysql", "root:root@tcp(localhost:8306)/mysql")
+	require.NoError(s.T(), err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result, err := db.ExecContext(ctx, "delete from users where name='Jack'")
+	require.NoError(s.T(), err)
+	s.T().Log(result)
+}
+
+func (s *ServerTestSuite) TestTransaction() {
+	db, err := sql.Open("mysql", "root:root@tcp(localhost:8306)/mysql")
+	require.NoError(s.T(), err)
+	//ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	//defer cancel()
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		s.T().Fatalf("Failed to begin transaction: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx, "insert into users(name) VALUES ('Harry')")
+	if err != nil {
+		s.T().Fatalf("Failed to begin transaction: %v", err)
+	}
+
+	err = tx.Commit()
+	//err = tx.Rollback()
+	if err != nil {
+		s.T().Fatalf("Failed to commit: %v", err)
+	}
+}
+
 func TestServer(t *testing.T) {
 	suite.Run(t, new(ServerTestSuite))
 }


### PR DESCRIPTION
完成单库识别转发所有DML语句和事务相关操作，但还有问题在于开启事务时，context还没到超时时间，但context发起Done通道，引起事务调用awaitDone回滚事务，目前把超时行为关闭，优先跑通流程
<img width="682" alt="image" src="https://github.com/meoying/dbproxy/assets/18389102/8cce622a-84a2-494f-9218-a92dc947b608">